### PR TITLE
Log Braze impression when presenting a Judo-powered IAM

### DIFF
--- a/Sample/Judo Braze Demo App/AppDelegate.swift
+++ b/Sample/Judo Braze Demo App/AppDelegate.swift
@@ -47,7 +47,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ABKInAppMessageController
     }
 
     @IBAction func buttonClicked(_ sender: Any) {
-        // Fire a Braze Event. If you have an appropriate campaign set up in your Braze settings for this event to open an IAP with the `judo-experience` extra field added, then this should open the Experience.
+        // Fire a Braze Event. If you have an appropriate campaign set up in your Braze settings for this event to open an IAM with the `judo-experience` extra field added, then this should open the Experience.
         Appboy.sharedInstance()?.logCustomEvent("My Test Event")
     }
     

--- a/Sources/Judo-Braze/Judo_Braze.swift
+++ b/Sources/Judo-Braze/Judo_Braze.swift
@@ -8,7 +8,7 @@ private var observerChit: NSObjectProtocol!
 public extension Judo {
     /// Call this method to automatically track Judo events into Braze.
     ///
-    /// Note to enable IAP integration there is further work to do, please see the documentation included with this module.
+    /// Note to enable IAM integration there is further work to do, please see the documentation included with this module.
     func integrateWithBraze() {
         if #available(iOS 13.0, *) {
             observerChit = NotificationCenter.default.addObserver(
@@ -31,13 +31,14 @@ public extension Judo {
         }
     }
     
-    /// This method a helper for launching Judo Experiences when a `judo-experience` extra is added to a Braze In-App message, which you can use from a  `ABKInAppMessageControllerDelegate`. See the documentation included with this module for more details.
+    /// This method a helper for launching Judo Experiences when a `judo-experience` extra is added to a Braze In-App Message, which you can use from a  `ABKInAppMessageControllerDelegate`. See the documentation included with this module for more details.
     func brazeBeforeInAppMessageDisplayed(inAppMessageDisplayed inAppMessage: ABKInAppMessage) -> ABKInAppMessageDisplayChoice? {
         // https://www.braze.com/docs/developer_guide/platform_integration_guides/ios/in-app_messaging/implementation_guide/#custom-slideup-in-app-message
         
         if let urlString = inAppMessage.extras?["judo-experience"] as? String, let experienceURL = URL(string: urlString) {
             Judo.sharedInstance.openURL(experienceURL, animated: true)
-            // Since we are doing our own behaviour, inhibit Braze's built-in IAP UI from displaying anything.
+            inAppMessage.logInAppMessageImpression()
+            // Since we are doing our own behaviour, inhibit Braze's built-in IAM UI from displaying anything.
             return ABKInAppMessageDisplayChoice.discardInAppMessage
         }
         return nil


### PR DESCRIPTION
As per the Braze [documentation for custom In-App Messaging UIs](https://www.braze.com/docs/developer_guide/platform_integration_guides/ios/in-app_messaging/customization/#logging-impressions-and-clicks) (that replace the stock Braze one), such custom UIs are responsible for calling Braze's impression log routine.

This was neglected in the initial implementation of the module.